### PR TITLE
Extending TOX matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ classifiers=[
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "xrft>=0.3.0",
-  "xarray>=0.20",
-  "pandas>=1.3.3",
+  "xrft>=0.3",
+  "xarray>=0.21",
+  "pandas>=1.4",
   "numpy>=1.22",
   "netCDF4 >= 1.5",
   "matplotlib>=3.4.3",

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,11 @@ skip_missing_interpreters = true
 [testenv]
 deps =
   pytest>=6.0
-  netcdf15: netCDF4>=1.5,<1.6
-  netcdf16: netCDF4~=1.6.0
+  netcdf15: netCDF4~=1.5
+  netcdf16: netCDF4>=1.6.0
   numpy122: numpy>=1.22,<1.23
   numpy123: numpy>=1.23,<1.24
-  numpy124: numpy~=1.24.0
+  numpy124: numpy>=1.24.0
   pandas14: pandas>=1.4,<1.5
   pandas15: pandas~=1.5.0
   pandas20: pandas>=2.0
@@ -22,7 +22,7 @@ deps =
   xarray2023: xarray>=2023.0
   xrft03: xrft>=0.3,<0.4
   xrft04: xrft>=0.4,<0.5
-  xrft10: xrft~=1.0.0
+  xrft10: xrft>=1.0.0
 commands =
     pip install -U pip
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-#envlist = py{38,39,310}-numpy{124}-pandas{15,20}-xarray{2022, 2023}-xrft{10}-netcdf{15}
-envlist = py{38,39,310}-numpy{122,123,124}-pandas{14,15}-xarray{20,21,22}-xrft{03,04,10}-netcdf{15,16}
+envlist = py{38,39,310,311}-numpy{122,123,124}-pandas{14,15,20}-xarray{21,2022,2023}-xrft{03,04,10}-netcdf{15,16}
 minversion = 3.12
 isolated_build = true
 skip_missing_interpreters = true


### PR DESCRIPTION
@jdiasn , it works as it is for me, but there are too many combinations. It might be a good idea to bump a little the dependencies and reduce the versions to test here. What do you think?

Remove:
* numpy 1.22
* pandas 1.4
* xarray 21
* xrft 0.3 & 0.4

Maybe we can assume that numpy is stable enough to just remove it from tox?